### PR TITLE
added new tomcat and jenkins profiles using official tomcat module

### DIFF
--- a/manifests/app/jenkins.pp
+++ b/manifests/app/jenkins.pp
@@ -1,7 +1,8 @@
+#Profile to install jenkins app on top of standard tomcat install
 class profile::app::jenkins (
   $version = 'latest',
-  $catalina_base = "/opt/apache-tomcat",
-  $catalina_home = "/opt/apache-tomcat",
+  $catalina_base = '/opt/apache-tomcat',
+  $catalina_home = '/opt/apache-tomcat',
 ) {
   include profile::staging
   include java
@@ -15,7 +16,7 @@ class profile::app::jenkins (
   }
   tomcat::war { "jenkins-${version}.war" :
     war_source    => "http://master.inf.puppetlabs.demo/war/${version}/jenkins.war",
-    catalina_base => "${catalina_base}",
+    catalina_base => $catalina_base,
     before        => File["${catalina_base}/webapps/jenkins"],
     notify        => File["${catalina_base}/webapps/jenkins"],
   }
@@ -23,10 +24,10 @@ class profile::app::jenkins (
     ensure => 'link',
     target => "${catalina_base}/webapps/jenkins-${version}",
   }
-  tomcat::service { "jenkins":
-    catalina_base => "${catalina_base}",
-    catalina_home => "${catalina_home}",
-    service_name  => "jenkins",
+  tomcat::service { 'jenkin':
+    catalina_base => $catalina_base,
+    catalina_home => $catalina_home,
+    service_name  => 'jenkins',
     subscribe     => File["${catalina_base}/webapps/jenkins"],
   }
 }

--- a/manifests/tomcat.pp
+++ b/manifests/tomcat.pp
@@ -1,3 +1,4 @@
+#Profile class to define use of the puppetlabs-tomcat module
 class profile::tomcat (
   $version = '7',
   $catalina_base = '/opt/apache-tomcat',
@@ -5,8 +6,9 @@ class profile::tomcat (
   $instance_name = 'default',
 ) {
   case $version {
-     '6': { $tomcat_minor_version = '6.0.35' }
-     '7': { $tomcat_minor_version = '7.0.25' }
+    '6': { $tomcat_minor_version = '6.0.35' }
+    '7': { $tomcat_minor_version = '7.0.25' }
+    default: { $tomcat_minor_version = '7.0.25'}
   }
   include profile::firewall
   include ::tomcat
@@ -14,8 +16,8 @@ class profile::tomcat (
     install_from_source    => true,
     source_url             => "http://master.inf.puppetlabs.demo/tomcat/apache-tomcat-${tomcat_minor_version}.tar.gz",
     source_strip_first_dir => false,
-    catalina_base          => "${catalina_base}",
-    catalina_home          => "${catalina_home}",
+    catalina_base          => $catalina_base,
+    catalina_home          => $catalina_home,
   }
   firewall { '100 allow connections to tomcat':
     proto   => 'tcp',


### PR DESCRIPTION
While tomcat version 7.0.25 of tomcat is used here, it does not seem to be able to properly handle the way the tomcat module refreshes the tomcat service and reloads the new Jenkins version. I think we should bump up to 7.0.57 which is the current latest version which handles this properly. This also requires replacing the current tomcat module in the environment with the official one from the Puppet Forge.
