### PR TITLE
Update the local repo definition with OS version

### DIFF
--- a/manifests/se_repo.pp
+++ b/manifests/se_repo.pp
@@ -1,6 +1,9 @@
 class profile::se_repo {
+
+  $repo = "${::osfamily}-${::operatingsystemmajrelease}-${::architecture}"
+
   yumrepo { 'se-repo':
-    baseurl  => "http://${::servername}/rpms",
+    baseurl  => "http://${::servername}/yumrepo/${repo}",
     descr    => 'SE Cached Files',
     enabled  => 1,
     gpgcheck => 1,


### PR DESCRIPTION
Previously the local repo was a single-directory repository. This worked while all we had using it was RedHat 6 based systems, but when we added RedHat 7 to the mix we realized that we had to have separate yum repos for different platforms. This commit replaces the single "rpms" directory with an OS and version sensitive directory name, such as "RedHat-6". We are intentionally not adding architecture.
