### PR TITLE
(SET-37) Enable boolean values for offline param

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -1,18 +1,18 @@
 # this is the offline class, it gets applied to all agents
 # and ensures they are able to work with local on networks
 class profile::repos (
-  $offline = 'false',
+  $offline = false,
 ) {
   include stdlib::stages
 
   case "$::osfamily $::operatingsystemmajrelease" {
     "RedHat 6": {
       class { '::profile::se_repo':
-      stage => 'setup',
-      }
-      if $offline == 'true' {
-        class { '::profile::el6_repo_disabled':
         stage => 'setup',
+      }
+      if $offline {
+        class { '::profile::el6_repo_disabled':
+          stage => 'setup',
         }
       }
     }


### PR DESCRIPTION
```
Previously, users needed to pass the string "true" to the
profile::repos::offline parameter to achieve desired behavior; the
boolean value True would not result in the base, updates, and other
repositories being disabled.

This commit modifies the profile::repos class such that any non-false
value will correctly enable the behavior.

We do not currently perform any type checking. Once type checking is
built into the language, we can enforce that the value given is boolean.
Until then for this code it makes more sense to keep it visually clean
than to enforce boolean values.
```
