### PR TITLE
move puppet binaries to end of shell PATH

### DIFF
--- a/manifests/pe_env.pp
+++ b/manifests/pe_env.pp
@@ -9,7 +9,7 @@ class profile::pe_env {
 
   file_line { 'root_puppet_path':
     ensure  => present,
-    line    => 'PATH=/opt/puppet/bin:$PATH; export PATH',
+    line    => 'PATH=${PATH}:/opt/puppet/bin; export PATH',
     path    => '/root/.bashrc',
     require => File['/root/.bashrc'],
   }


### PR DESCRIPTION
Prior to this comment, puppet overrides system commands with vendored 
versions. This is not a recommended or supported configuration, and in
particular causes problems with trying to use non-vendored rubygems.
